### PR TITLE
Add mixin

### DIFF
--- a/model/model.py
+++ b/model/model.py
@@ -459,7 +459,7 @@ class TwinLiteNetPlus(nn.Module,
     This class defines the ESPNet network
     '''
 
-    def __init__(self, args=None):
+    def __init__(self, args: Namespace = None):
 
         super().__init__()
         chanel_img = cfg.chanel_img

--- a/model/model.py
+++ b/model/model.py
@@ -1,3 +1,5 @@
+from argparse import Namespace
+
 import torch
 import torch.nn as nn
 import numpy as np
@@ -8,6 +10,8 @@ import matplotlib.pyplot as plt
 from torch.nn import Module, Conv2d, Parameter, Softmax
 import cv2
 import os
+
+from huggingface_hub import PyTorchModelHubMixin
 
 
 
@@ -440,7 +444,17 @@ class UpConvBlock(nn.Module):
         x = self.conv2(x)
         return x
 
-class TwinLiteNetPlus(nn.Module):
+class TwinLiteNetPlus(nn.Module,
+                      PyTorchModelHubMixin,
+                      repo_url="https://github.com/chequanghuy/TwinLiteNetPlus.git",
+                      pipeline_tag="image-segmentation",
+                      license="mit",
+                      coders={
+                            Namespace : (
+                                lambda x: vars(x),
+                                lambda data: Namespace(**data),
+                            )
+    }):
     '''
     This class defines the ESPNet network
     '''

--- a/push_and_load.py
+++ b/push_and_load.py
@@ -1,0 +1,33 @@
+import torch
+from argparse import ArgumentParser
+
+from model.model import TwinLiteNetPlus
+
+
+def detect(args):
+
+    # load model
+    model = TwinLiteNetPlus(args)
+    model = model
+
+    # load weights
+    state_dict = torch.load(args.weight, map_location="cpu")
+    model.load_state_dict(state_dict)
+
+    # push model
+    model.push_to_hub(f"nielsr/twinlitenetplus-{args.config}")
+
+    # test load model
+    model = TwinLiteNetPlus.from_pretrained(f"nielsr/twinlitenetplus-{args.config}")
+
+
+if __name__ == '__main__':
+    parser = ArgumentParser()
+    parser.add_argument('--weight', type=str, default='pretrained/large.pth', help='model.pth path(s)')
+    parser.add_argument('--source', type=str, default='inference/videos', help='source')  # file/folder   ex:inference/images
+    parser.add_argument('--img-size', type=int, default=640, help='inference size (pixels)')
+    parser.add_argument('--config', type=str, choices=["nano", "small", "medium", "large"], help='Model configuration')
+    parser.add_argument('--save-dir', type=str, default='inference/output', help='directory to save results')
+    opt = parser.parse_args()
+    with torch.no_grad():
+        detect(opt)


### PR DESCRIPTION
This PR showcases how to leverage the [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/en/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) class. 

Fixes #1 

If you run the `push_and_load.py` script, you end up with a model on the hub: https://huggingface.co/nielsr/twinlitenetplus-nano.

You can then reload it like so:

```python
from model.model import TwinLiteNetPlus

model = TwinLiteNetPlus.from_pretrained("nielsr/twinlitenetplus-nano")
```

Could you try it out for all model sizes, and push it to your HF account? See [this notebook](https://colab.research.google.com/drive/1iF3r0xOi45vhzESH2AVaIB8AxGOCooH9?usp=sharing).